### PR TITLE
Refactor GitHub Actions workflow to remove draft release job and upda…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,24 +5,6 @@ on:
     tags:
       - "v*.*.*"
 jobs:
-  draft-release:
-    if: startsWith(github.ref, 'refs/heads/main')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Create/Update release draft
-        uses: release-drafter/release-drafter@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   publish-to-github-and-pypi:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
@@ -65,11 +47,11 @@ jobs:
       - name: Create or Update GitHub Release and Upload Assets
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref }}
-          name: Release ${{ github.ref }}
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
           body: ${{ steps.get_release_notes.outputs.release_notes }}
           draft: false
-          prerelease: ${{ contains(github.ref, '-beta') || contains(github.ref, '-rc') }}
+          prerelease: ${{ contains(github.ref_name, '-beta') || contains(github.ref_name, '-rc') }}
           files: |
             ./dist/*.whl
             ./dist/*.tar.gz


### PR DESCRIPTION
…te tag handling

- Removed the draft-release job from the release workflow.
- Updated tag handling to use `github.ref_name` instead of `github.ref` for release name and prerelease checks.